### PR TITLE
Add the option to switch prologix mode in the wrapper

### DIFF
--- a/LabDrivers/utils.py
+++ b/LabDrivers/utils.py
@@ -47,6 +47,8 @@ INTF_SERIAL = 'serial'
 INTF_NONE = 'None'
 
 PROLOGIX_COM_PORT = "COM5"
+# cf section 8.2 of the manual : http://prologix.biz/downloads/PrologixGpibUsbManual-6.0.pdf
+PROLOGIX_AUTO = 'prologix_auto_opt'
 
 LABDRIVER_PACKAGE_NAME = "LabDrivers"
 

--- a/LabDrivers/utils.py
+++ b/LabDrivers/utils.py
@@ -444,7 +444,7 @@ class PrologixController(object):
         if not cmd.endswith('\n'):
             cmd += '\n'
         if self.connection is not None:
-            logging.debug("Prologix in : ", cmd)
+            logging.debug("Prologix in : %s" % cmd)
             self.connection.write(cmd.encode())
 
     def read(self, num_bit):
@@ -453,7 +453,7 @@ class PrologixController(object):
             if not self.auto:
                 self.write('++read eoi')
             answer = self.connection.read(num_bit)
-            logging.debug("Prologix out (read) : ", answer)
+            logging.debug("Prologix out (read) : %s" % answer)
             return answer.decode()
         else:
             return ''
@@ -464,7 +464,7 @@ class PrologixController(object):
             if not self.auto:
                 self.write('++read eoi')
             answer = self.connection.readline()
-            logging.debug("Prologix out (readline): ", answer)
+            logging.debug("Prologix out (readline): %s " % answer)
             return answer.decode()
         else:
             return ''

--- a/LabDrivers/utils.py
+++ b/LabDrivers/utils.py
@@ -337,32 +337,42 @@ def test_prologix_controller_creation_with_no_arg_conflict():
 
 
 class PrologixController(object):
-
     connection = None
 
-    def __init__(self, com_port=None, debug=False, baud_rate=9600, timeout=3):
+    def __init__(
+            self,
+            com_port=None,
+            debug=False,
+            auto=1,
+            baud_rate=9600,
+            timeout=5,
+            **kwargs
+    ):
 
         self.debug = debug
 
         if not self.debug:
-
             if com_port is None:
                 # the user didn't provide a COM port, so we look for one
                 com_port = find_prologix_ports()
 
-                if com_port != []:
-
+                if com_port:
                     if len(com_port) > 1:
                         logging.warning("There is more than one Prologix \
-                         controller, we are connecting to %s" % com_port[0])
+                         controller, we are connecting to %s" % (com_port[0]))
 
                     com_port = com_port[0]
+                    logging.info(
+                        "... found a Prologix controller on the port '%s'" %
+                        com_port
+                    )
 
                     self.connection = serial.Serial(
-                        com_port, baud_rate, timeout=timeout)
-
+                        com_port,
+                        baud_rate,
+                        timeout=timeout
+                    )
                 else:
-
                     self.connection = None
                     logging.warning(
                         "There is no Prologix controller to connect to")
@@ -370,48 +380,54 @@ class PrologixController(object):
             else:
 
                 try:
-
                     self.connection = serial.Serial(
-                        com_port, baud_rate, timeout=timeout)
-
+                        com_port,
+                        baud_rate,
+                        timeout=timeout
+                    )
                 except serial.serialutil.SerialException:
-
                     self.connection = None
-                    logging.error(
-                        "The port %s is not attributed to any device" % com_port
+                    logging.warning(
+                        "The port %s is not attributed to any device"
+                        % com_port
                     )
 
             if self.connection is not None:
-
                 # set the connector in controller mode and let the user
-                # ask for read without sending another command.
                 self.write("++mode 1")
-                self.write("++auto 1")
+                # auto == 1 : ask for read without sending another command.
+                # auto == 0 : simply send the command.
+                self.auto = auto
+                self.write("++auto %i" % self.auto)
 
                 # check the version
                 self.write("++ver")
-                version_number = self.readline()
+                # important not to use the self.readline() method
+                # at this stage if auto == 0, otherwise the connector is going
+                # to prompt the instrument for a reading an generate an error
+                version_number = (self.connection.readline()).decode()
 
                 if "Prologix GPIB-USB Controller" not in version_number:
                     self.connection = None
                     logging.error(
-                        "The port %s isn't related to a Prologix controller (try to plug and unplug "
-                        "the cable if it is there nevertheless)" % com_port
+                        "The port %s isn't related to a Prologix controller "
+                        "(try to plug and unplug the cable if it is there "
+                        "nevertheless). Returned version number : %s" % (
+                            com_port,
+                            version_number
+                        )
                     )
-
                 logging.info(
-                    "%s is connected on the port '%s'" % (version_number[:-2], com_port)
+                    "%s is connected on the port '%s'"
+                    % (version_number[:-2], com_port)
                 )
             else:
-
-                logging.error(
-                    "The connection to the Prologix connector failed"
-                )
+                logging.error("The connection to the Prologix connector failed")
 
     def __str__(self):
         if self.connection is not None:
             self.write("++ver")
-            return self.readline()
+            return (self.connection.readline()).decode()
         else:
             return ""
 
@@ -420,32 +436,39 @@ class PrologixController(object):
 
     def write(self, cmd):
         """use serial.write"""
-        if cmd[-1] != "\n":
-            cmd += "\n"
+        # add a new line if the command didn't have one already
+        if not cmd.endswith('\n'):
+            cmd += '\n'
         if self.connection is not None:
-            #             print "Prologix in : ", cmd
-            self.connection.write(cmd)
+            #  print("Prologix in : ", cmd)
+            self.connection.write(cmd.encode())
 
     def read(self, num_bit):
         """use serial.read"""
         if self.connection is not None:
-            return self.connection.read(num_bit)
+            if not self.auto:
+                self.write('++read eoi')
+            answer = self.connection.read(num_bit)
+            # print("Prologix out (read) : ", answer)
+            return answer.decode()
         else:
             return ""
 
     def readline(self):
         """use serial.readline"""
         if self.connection is not None:
+            if not self.auto:
+                self.write('++read eoi')
             answer = self.connection.readline()
-#             print "Prologix out : ", answer
-            return answer
+            logging.debug("Prologix out (readline): ", answer)
+            return answer.decode()
         else:
             return ""
 
     def timeout(self, new_timeout=None):
         """
         query the timeout setting of the serial port if no argument provided
-        change the 
+        change the timeout setting to new_timout if the latter is not None
         """
         if self.connection is not None:
             if new_timeout is None:
@@ -456,7 +479,7 @@ class PrologixController(object):
                 return old_timeout
 
     def get_open_gpib_ports(self, num_ports=30):
-        """Finds out which GPIB ports are available through prologix controller"""
+        """Finds out which GPIB ports are available for prologix controller"""
         open_ports = []
 
         if not self.debug:
@@ -480,7 +503,6 @@ class PrologixController(object):
 
             # resets the timeout to its original value
             self.timeout(old_timeout)
-    #        print "Time out is", self.timeout()
 
         return open_ports
 
@@ -500,11 +522,11 @@ def command_line_test(instrument_class):
     msg += " and responds to commands."
     print(msg)
 
-    stri = raw_input("Please enter port to connect to: ")
+    stri = input("Please enter port to connect to: ")
     inst = instrument_class(stri)
 
     while True:
-        stri = raw_input("Enter command or type x to quit: ")
+        stri = input("Enter command or type x to quit: ")
         if stri.lower() == 'x':
             break
         try:

--- a/LabDrivers/utils.py
+++ b/LabDrivers/utils.py
@@ -440,7 +440,7 @@ class PrologixController(object):
         if not cmd.endswith('\n'):
             cmd += '\n'
         if self.connection is not None:
-            #  print("Prologix in : ", cmd)
+            logging.debug("Prologix in : ", cmd)
             self.connection.write(cmd.encode())
 
     def read(self, num_bit):
@@ -449,7 +449,7 @@ class PrologixController(object):
             if not self.auto:
                 self.write('++read eoi')
             answer = self.connection.read(num_bit)
-            # print("Prologix out (read) : ", answer)
+            logging.debug("Prologix out (read) : ", answer)
             return answer.decode()
         else:
             return ""


### PR DESCRIPTION
For certain instruments the option `auto` of the prologix GPIB-USB set in `controller mode` should have the possibility be set to either on of off (cf the [manual](http://prologix.biz/downloads/PrologixGpibUsbManual-6.0.pdf)). 

`auto` enables/disable read-after-write command send to the instrument, it is well described in the section 8.2 of the Prologix [manual](http://prologix.biz/downloads/PrologixGpibUsbManual-6.0.pdf)

