### PR TITLE
Hotfix for script namespace issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ StartLabGui*
 labgui.egg-info
 bin/
 dist*
+*.dump

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ StartLabGui*
 labgui.egg-info
 bin/
 dist*
-*.dump

--- a/LabTools/DataManagement.py
+++ b/LabTools/DataManagement.py
@@ -165,7 +165,9 @@ user variable")
                 return self.assign_user_variable(key, value_type)
 
     def run(self):
-
+        """
+            related to https://github.com/LabGUI/LabGUI/pull/23
+        """
         rel_path = os.path.basename(os.path.abspath(os.path.curdir))
         rel_path = self.script_file_name.split(rel_path)[1]
 

--- a/LabTools/DataManagement.py
+++ b/LabTools/DataManagement.py
@@ -185,8 +185,24 @@ user variable")
             script = open(userScriptName)
             py_compile.compile(script.name, doraise=True)
             code = compile(script.read(), script.name, 'exec')
+            """
+                The following insertion is necessary for the following:
+                    For a local variable to be created and then utilized without unexpected results,
+                    typically globals() and locals() are called, which causes anything from within the script
+                    to modify the globals or locals in this namespace. This can cause a problem if, for example,
+                    a local variable is created, then a list comprehension is used, which searches for the 
+                    aforementioned variable under globals, to which it is not found, and thus throws an error.
+                    
+                    By creating a copy of the globals under this namespace, and resetting self so that it can be
+                    properly executed within the script, and finally setting both local and global variables to the
+                    same dict, any variables declared within the script will act both globally and locally, as well as
+                    be unable to modify any of the inner-workings of LabGUI, maintaining the required namespace: that
+                    of the datataker class.
+            """
+            namespace = globals().copy()
+            namespace['self'] = self
 
-            exec(code)
+            exec(code, namespace, namespace)
             script.close()
 
             self.running = False


### PR DESCRIPTION
In the lab, we were having an issue with certain scripts being run. After some research and test scripts designed to recreate the error and identify the cause, I determined that it was because variable declaration would affect locals(), whereas it being called anywhere that isnt local (ex, list comprehension, function declaration) would throw a NameError. This included importing libraries (in this case, numpy).

The solution I determined was to create a copy of globals, update globals['self'] = self so that the script would continue to operate under DataTaker, and then pass the same dictionary as both locals and globals to exec, thus superficially mending this error, as when a local variable is declared within the script, it is created under the same dictionary object as globals, allowing it to be used within functions/classes/list comprehensions.

