### PR TITLE
SIM928 Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ StartLabGui*
 labgui.egg-info
 bin/
 dist*
+*.dump

--- a/LabDrivers/SIM900.py
+++ b/LabDrivers/SIM900.py
@@ -364,6 +364,10 @@ class Instrument(Tool.MeasInstr):
         return None
 
     def set_voltage(self, channel, voltage):
+        """
+        voltage must be rounded to 3 decimal places, as SIM928 cannot process larger floating points. For example,
+        if the voltage 1.8889 is given, it will be unable to process it, however it would be able to process 1.889
+        """
         channel = str(channel)
         voltage = str(round(float(voltage),3))
         if channel in self.connections.keys():

--- a/LabDrivers/SIM900.py
+++ b/LabDrivers/SIM900.py
@@ -29,6 +29,12 @@ import sys
 
 #param = {'CH1': 'V', 'CH2': 'V', 'phase': 'deg', 'Z': 'Ohm', 'Z2': 'Ohm'}
 param = {'Summing Offset Voltage':'microV'}
+# 'SIM928 Voltage':'V'
+# create SIM928 on all possible channels
+for i in range(1, 9): # to add reading
+    param['SIM928 Chan %d'%i] = 'V'
+
+SIM928_READ_CHANNEL = 4
 
 # for summing offset voltage
 SIM928 = 4
@@ -190,6 +196,13 @@ class Instrument(Tool.MeasInstr):
                 answer = float(answer)
             else:
                 answer = None
+
+        elif channel.startswith('SIM928'):
+            answer = self.get_voltage(int(channel[-1]))
+            if answer is None:
+                answer = float('nan')
+            else:
+                answer = float(answer)
         else:
             print("invalid measurement channel: "+channel)
             return -1
@@ -352,7 +365,7 @@ class Instrument(Tool.MeasInstr):
 
     def set_voltage(self, channel, voltage):
         channel = str(channel)
-        voltage = str(float(voltage))
+        voltage = str(round(float(voltage),3))
         if channel in self.connections.keys():
             # check if SIM928
             if self.connections[channel] == 'SIM928':


### PR DESCRIPTION
In taking data, we noticed that there were some bugs in regards to setting the voltage on the SIM928, should the number not be rounded to 3 decimal places. Moreover, some "quality of taking data" changes were added, such as adding the ability to read the output voltage that you set in a script, and have it plot with other measurements.