### PR TITLE
Hotfix/buffer clear (severity=high)

### DIFF
--- a/LabDrivers/ITC503S.py
+++ b/LabDrivers/ITC503S.py
@@ -47,6 +47,7 @@ class Instrument(Tool.MeasInstr):
             itfc = INTERFACE
 
         name='ITC503S'
+        self.identification = "Oxford Instrument Intelligent Temperature Controller 503"
         if "name" in kwargs:
             name = kwargs.pop("name")
             print(name)

--- a/LabDrivers/ITC503S.py
+++ b/LabDrivers/ITC503S.py
@@ -180,6 +180,9 @@ class Instrument(Tool.MeasInstr):
         # the way it works is An, where n is a decimal number, whos first bit (2^0) represents if heater is auto, and second bit represents if gas flow is auto
         self.write("$A"+str(commandcode))
 
+    def setDesiredTemperature(self, temperature):
+        self.write("$T"+str(temperature))
+
     def setSweep(self, line, PointTemperature, SweepTime, HoldTime):
         line = int(line)
         if (line >= 1) and (line <= 16):

--- a/LabDrivers/Tool.py
+++ b/LabDrivers/Tool.py
@@ -490,6 +490,9 @@ file to see which are the ones implemented" % (self.ID_name, resource_name))
                     self.connection.clear()
                     print("cleared " + self.ID_name)
 
+                elif hasattr(self.connection, "clear"):
+                    getattr(self.connection, "clear")()
+
 
             except:
 
@@ -1012,6 +1015,17 @@ which is connected to %s " % (param, instr_name, device_port))
         """change the DEBUG property of the IntrumentHub instance"""
         self.DEBUG = state
         logging.debug("debug mode of InstrumentHub Object :%s" % self.DEBUG)
+
+    def clear(self):
+        """ Attempts to clear every buffer of every connected device """
+        for port, inst in list(self.instrument_list.items()):
+            if hasattr(inst, "clear"):
+                inst.clear()
+                if self.DEBUG:
+                    logging.debug("%s cleared"%port)
+            else:
+                if self.DEBUG:
+                    logging.debug("%s not cleared"%port)
 
     def clean_up(self):
         """ closes all instruments and reset the lists and dictionnaries """

--- a/LabDrivers/Tool.py
+++ b/LabDrivers/Tool.py
@@ -254,7 +254,8 @@ class MeasInstr(object):
                 if hasattr(self, 'identification'):
                     return self.identification
                 else:
-                    return "Unknown instrument"
+                    return "Unknown instrument" \
+                           ""
             else:
                 return "Unknown instrument"
 
@@ -1028,7 +1029,7 @@ which is connected to %s " % (param, instr_name, device_port))
         """ Attempts to clear every buffer of every connected device """
         for port, inst in list(self.instrument_list.items()):
             if hasattr(inst, "clear"):
-                inst.clear(True)
+                inst.clear(silent=True)
                 logging.debug("%s cleared (port %s)"%(inst, port))
             else:
                 logging.debug("%s not cleared (port %s)"%(inst, port))

--- a/LabTools/DataManagement.py
+++ b/LabTools/DataManagement.py
@@ -246,6 +246,7 @@ user variable")
                 print("DTT stopped and complete")
             else:
                 print("DTT stopped but not complete")
+                self.instr_hub.clear()
 
         finally:
 


### PR DESCRIPTION
This bug came to late when manipulating the ITC503S manually while taking data would cause the DTT to fail, and upon rerunning would shift all the temperature readings. It was determined that the cause of this shift was due to a specific temperature reading remaining in the buffer. The fix was to add a method that clears the output buffer of every device that supports it (PyVISA and PySerial support it natively, any other type of connection would require the user to write a "clear" function with signature clear(silent=False) or clear(**kwargs) within the driver file if they wish for this functionality to work with their device, otherwise it would simply not clear).

Moreover, some added functionality to Instrument.clear was written, which takes in the parameter silent, a boolean, which by default is set to False. If silent = True, then the function will not print to stdout that the device was cleared.

I consider this bug of high severity, as any/every device can be vulnerable, which could cause an entire set of data to be incorrect