### PR TITLE
Small bugfix to stop datafile from incrementing twice when datataker …

### DIFF
--- a/LabGui.py
+++ b/LabGui.py
@@ -1116,7 +1116,6 @@ have the right format, '%s' will be used instead"
         self.stop_DTT_action.setEnabled(True)
 
     def stop_DTT(self):
-
         if self.datataker.isRunning():
 
             self.datataker.ask_to_stop()
@@ -1148,7 +1147,7 @@ have the right format, '%s' will be used instead"
         self.output_file.write(data)
         self.output_file.close()
 
-        self.widgets["OutputFileWidget"].increment_filename()
+
 
     def DTT_script_finished(self, completed):
         """signal triggered by the completion of the script
@@ -1159,6 +1158,8 @@ have the right format, '%s' will be used instead"
         """
 
         self.stop_DTT()
+        # we should increment the file only after the datataker is stopped.
+        self.widgets["OutputFileWidget"].increment_filename()
 
     def DTT_isRunning(self):
         """indicates whether the datataker is running or not"""

--- a/LabTools/CoreWidgets/OutputFileWidget.py
+++ b/LabTools/CoreWidgets/OutputFileWidget.py
@@ -86,7 +86,7 @@ class OutputFileWidget(QtGui.QWidget):
 
         found = p.findall(fname)
 #        print(("found:" + str(found)))
-        if not found == []:
+        if not len(found) == []:
             ending = found[0]
             num = int(ending[1:4]) + 1
             fname = fname.replace(ending, "_%3.3d.dat" % num)

--- a/LabTools/CoreWidgets/OutputFileWidget.py
+++ b/LabTools/CoreWidgets/OutputFileWidget.py
@@ -86,7 +86,7 @@ class OutputFileWidget(QtGui.QWidget):
 
         found = p.findall(fname)
 #        print(("found:" + str(found)))
-        if not len(found) == []:
+        if not found == []:
             ending = found[0]
             num = int(ending[1:4]) + 1
             fname = fname.replace(ending, "_%3.3d.dat" % num)

--- a/LabTools/IO/IOTool.py
+++ b/LabTools/IO/IOTool.py
@@ -203,7 +203,6 @@ def get_file_name(config_file_path=CONFIG_FILE_PATH):
         config_file.close()
     except IOError:
         print("No configuration file " + config_file_path + "  found")
-
     return file_name
 
 def get_funct_save_name(device, funct, config_file_path=CONFIG_FILE_PATH):


### PR DESCRIPTION
When DTT is stopped manually, LabGUI.stop_dtt is called twice, which in turn increments the savefile twice. This was moved to the function DTT_script_finished which is called after the datataker is stopped.