### PR TITLE
OutputFileWidget issues

### DIFF
--- a/LabTools/CoreWidgets/OutputFileWidget.py
+++ b/LabTools/CoreWidgets/OutputFileWidget.py
@@ -71,11 +71,14 @@ class OutputFileWidget(QtGui.QWidget):
 
     def on_outputFileButton_clicked(self):
 
-        fname = str(QtGui.QFileDialog.getSaveFileName(self, 'Save output file as',
+        fname = (QtGui.QFileDialog.getSaveFileName(self, 'Save output file as',
                                                       self.outputFileLineEdit.text()))
-
+        if fname and type(fname) == tuple:
+            fname,_ = fname
+        if fname and type(fname) != str:
+            fname = str(fname)
+        
         if fname:
-
             self.outputFileLineEdit.setText(fname)
 
     def increment_filename(self):


### PR DESCRIPTION
Changes in QFileDialog made it so getSaveFileName() returns a tuple instead of simply the selected path. To provide backward compatibility, the change made checks if fname returned is a tuple, in which case it takes the first entry (the file name). Without this change, the fname set in the outputFileWidget included the full tuple and would cause a crash.